### PR TITLE
Upgrade from bullseye to bookworm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,12 @@
 set -e
 cd /github/home
 echo Install dependencies.
-echo deb http://deb.debian.org/debian bullseye-backports main >> /etc/apt/sources.list
 apt-get update > /dev/null 2>&1
 apt-get install --allow-change-held-packages --allow-downgrades --allow-remove-essential \
 -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold -fy \
 cmake git libmaxminddb-dev wget > /dev/null 2>&1
 wget -qO /etc/apt/trusted.gpg.d/nginx_signing.asc https://nginx.org/keys/nginx_signing.key
-echo deb-src https://nginx.org/packages/mainline/debian bullseye nginx \
+echo deb-src https://nginx.org/packages/mainline/debian bookworm nginx \
 >> /etc/apt/sources.list
 echo -e 'Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900' \
 > /etc/apt/preferences.d/99nginx


### PR DESCRIPTION
Should not break dependency. Keep major version number.